### PR TITLE
remove console.log left over from vscode extension template

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,9 +116,6 @@ function isInstalled(
 }
 
 export async function activate(context: ExtensionContext) {
-    console.log(
-        'Congratulations, your extension "distributed-package-manager" is now active!'
-    )
 
     const sources = workspace
         .getConfiguration('distributed-package-manager')


### PR DESCRIPTION
this unnecessarily pollutes dev console